### PR TITLE
Migrate get ignore-errors flag to optional

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        version: ["0.103.0", "*", "nightly"] # Earliest supported, latest and nightly
+        version: ["0.106.0", "*", "nightly"] # Earliest supported, latest and nightly
         platform: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [Nushell](https://www.nushell.sh) test framework.
 
 ## Requirements
 
-Needs Nushell 0.103.0 or later.
+Needs Nushell 0.106.0 or later.
 If Nushell 0.101.0+ is required, use Nutest v1.0.1.
 
 

--- a/nutest/completions.nu
+++ b/nutest/completions.nu
@@ -109,7 +109,7 @@ def parse-command-context []: string -> record<suite: string, test: string, path
 
 # A slight variation on get, which also translates empty strings to null
 def get-or-null [name: string]: record -> string {
-    let value = $in | get --ignore-errors $name
+    let value = $in | get --optional $name
     if ($value | is-empty) {
         null
     } else {

--- a/nutest/discover.nu
+++ b/nutest/discover.nu
@@ -110,7 +110,7 @@ def parse-type []: record<attributes: list<string>, description: string> -> stri
     $metadata.attributes
         | append ($metadata.description | description-attributes)
         | where $it in $supported_types
-        | get 0 --ignore-errors
+        | get 0 --optional
         | default "unsupported"
 }
 

--- a/nutest/display/display_terminal.nu
+++ b/nutest/display/display_terminal.nu
@@ -37,7 +37,7 @@ def complete-suite []: nothing -> nothing {
 
 def count [key: string]: record -> int {
     $in
-        | get --ignore-errors $key
+        | get --optional $key
         | default []
         | length
 }

--- a/nutest/returns/returns_summary.nu
+++ b/nutest/returns/returns_summary.nu
@@ -23,7 +23,7 @@ def query-summary []: nothing -> record<total: int, passed: int, failed: int, sk
 
 def count [key: string]: record -> int {
     $in
-        | get --ignore-errors $key
+        | get --optional $key
         | default []
         | length
 }

--- a/nutest/runner.nu
+++ b/nutest/runner.nu
@@ -41,11 +41,11 @@ def nutest-299792458-execute-suite-internal [
     let plan = $suite_data | group-by type
 
     def find-or-default [key: string, default: record]: record -> record {
-        let values = $in | get --ignore-errors $key
+        let values = $in | get --optional $key
         if ($values | is-empty) { $default } else { $values | first }
     }
     def get-or-empty [key: string]: record -> list {
-        $in | get --ignore-errors $key | default []
+        $in | get --optional $key | default []
     }
 
     # Also see the list in discover.nu


### PR DESCRIPTION
Nushell 0.106.0 renamed `--ignore-errors` to `--optional` as documented at https://www.nushell.sh/blog/2025-07-23-nushell_0_106_0.html#ignore-errors-i-renamed-to-optional-o-toc.