### PR TITLE
feat: don't display tests that pass on terminal output to reduce debugging noise

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Nushell Binary
         uses: hustcer/setup-nu@v3
@@ -103,10 +103,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Checkout Nushell
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: nushell/nushell
           ref: main

--- a/nutest/display/display_terminal.nu
+++ b/nutest/display/display_terminal.nu
@@ -55,13 +55,16 @@ def complete-test [theme: closure, formatter: closure]: record -> nothing {
         error make { msg: $"No test results found for: ($event)" }
     }
     let row = $result | first
-    let formatted = format-result $row.result $theme
 
-    if ($row.output | is-not-empty) {
-        let output = $row.output | format-output $formatter
-        print $"($formatted) ($suite) ($test)\n($output)"
-    } else {
-        print $"($formatted) ($suite) ($test)"
+    if $row.result != "PASS" {
+        let formatted = format-result $row.result $theme
+
+        if ($row.output | is-not-empty) {
+            let output = $row.output | format-output $formatter
+            print $"($formatted) ($suite) ($test)\n($output)"
+        } else {
+            print $"($formatted) ($suite) ($test)"
+        }
     }
 }
 


### PR DESCRIPTION
Avoid having to use the --match options when there are many tests.