### PR TITLE
fix: macOS test failures from /var symlink canonicalization (#16)

### DIFF
--- a/nutest/discover.nu
+++ b/nutest/discover.nu
@@ -30,7 +30,8 @@ def list-files [ pattern: string ]: string -> list<string> {
         [$path]
     } else {
         cd $path
-        glob $pattern
+        # We use `path expand` to normalise paths and needed on Mac that expands symlinks
+        glob $pattern | each { path expand }
     }
 }
 


### PR DESCRIPTION
* Initial plan

* Fix macOS path canonicalization in discover.nu

Apply path expand to glob results to ensure consistent path resolution. On macOS, /var is a symlink to /private/var, and this ensures both discover suite-files and test assertions return the same canonical paths.



* fix: add reasons normalize paths on macOS by expanding symlinks in discover

---------