### PR TITLE
fix: as of nushell/nushell#18271 `run` is nushell keyword

### DIFF
--- a/tests/display/test_display_table_errors.nu
+++ b/tests/display/test_display_table_errors.nu
@@ -38,7 +38,7 @@ def "assertion is compact" [] {
         assert equal 1 2
     }
 
-    let result = $in | run $test
+    let result = $in | do-run $test
 
     assert equal ($result.output | trim-all) ("
         Assertion failed.
@@ -54,7 +54,7 @@ def "basic compact" [] {
         error make { msg: 'some error' }
     }
 
-    let result = $in | run $code
+    let result = $in | do-run $code
 
     assert equal $result.output "some error"
 }
@@ -75,7 +75,7 @@ def "full unformatted" [] {
     }
 
     # Use default 'unformatted' formatter
-    let result = $in | run $code
+    let result = $in | do-run $code
 
     let error = $result.data.output.0 | errors unwrap-error
     let details = $error.json | from json
@@ -99,15 +99,15 @@ def "full compact" [] {
         }
     }
 
-    let result = $in | run $code
+    let result = $in | do-run $code
 
     assert equal $result.output "a decorated error\nsome help"
 }
 
 # See test_integration.nu / "terminal display with rendered error" for rendered test
 
-def run [code: closure]: record -> record<data: record, output: string> {
-    let result = $in | harness run $code
+def do-run [code: closure]: record -> record<data: record, output: string> {
+    let result = $in | harness do-run $code
     assert equal $result.result "FAIL"
 
     let output = do (display_table create).results

--- a/tests/harness.nu
+++ b/tests/harness.nu
@@ -31,7 +31,7 @@ export def cleanup-test []: record -> nothing {
     }
 }
 
-export def run [
+export def do-run [
     code: closure
     strategy: record = { }
 ]: record<temp_dir: string> -> record<result: string, output: any> {

--- a/tests/test_external_tools.nu
+++ b/tests/test_external_tools.nu
@@ -32,7 +32,7 @@ def non-captured-output-is-ignored [] {
         print "Only this text"
     }
 
-    let result = $in | harness run $code
+    let result = $in | harness do-run $code
 
     assert equal ($result | reject suite test) {
         result: "PASS"

--- a/tests/test_output.nu
+++ b/tests/test_output.nu
@@ -30,111 +30,111 @@ def cleanup-test []: record -> nothing {
 @test
 def nulls [] {
     let code = { print null }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [null] ]
 
     let code = { print null null null}
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [null, null, null] ]
 }
 
 @test
 def numbers [] {
     let code = { print 1 }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [1] ]
 
     let code = { print 1 2 3}
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [1, 2, 3] ]
 }
 
 @test
 def strings [] {
     let code = { print "str" }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ ["str"] ]
 
     let code = { print "one" "two" "three" }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ ["one", "two", "three"] ]
 }
 
 @test
 def durations [] {
     let code = { print 2min }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [2min] ]
 }
 
 @test
 def lists [] {
     let code = { print [] }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[]] ]
 
     let code = { print [1, "two", 3] }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[1, two, 3]] ]
 
     let code = { print [1, "two", 3] [4, "five", 6] }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[1, two, 3], [4, five, 6]] ]
 }
 
 @test
 def records [] {
     let code = { print {} }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [{}] ]
 
     let code = { print { a: 1, b: "two" } }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [{a: 1, b: two}] ]
 
     let code = { print { a: 1, b: "two" } { c: 3, d: "four" } }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [{a: 1, b: "two"}, {c: 3, d: "four"}] ]
 }
 
 @test
 def tables [] {
     let code = { print ([[a, b, c]; [1, 2, 3]] | take 0) }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[]] ]
 
     let code = { print [[a, b, c]; [1, "two", 3], [4, "five", 6]] }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[{a: 1, b: two, c: 3}, {a: 4, b: five, c: 6}]] ]
 
     let code = { print [[a, b, c]; [1, "two", 3]] [[d, e, f]; [4, "five", 6]] }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[{a: 1, b: two, c: 3}], [{d: 4, e: five, f: 6}]] ]
 }
 
 @test
 def "table in record" [] {
     let code = { print { a: 1, b: [[c, d]; [1, 2]] } }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [{a: 1, b: [{c: 1, d: 2}]}] ]
 }
 
 @test
 def "record in table" [] {
     let code = { print [[a, b]; [1, {c: 2, d: 3}]] }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [[[a, b]; [1, {c: 2, d: 3}]]] ]
 }
 
 @test
 def "capture print fidelity" [] {
     let code = { print 1; print 2 3; print "more" "args" }
-    let output = $in | run $code
+    let output = $in | do-run $code
     assert equal $output [ [1], [2, 3], ["more", "args"] ]
 }
 
-def run [code: closure]: record -> list<any> {
-    let result = $in | harness run $code
+def do-run [code: closure]: record -> list<any> {
+    let result = $in | harness do-run $code
     assert equal $result.result "PASS"
 
     query-results


### PR DESCRIPTION
Necessary for `nutest` to continue working on nightly (and on 0.114+)