### PR TITLE
Make error labels' spans file relative

### DIFF
--- a/nutest/orchestrator.nu
+++ b/nutest/orchestrator.nu
@@ -43,7 +43,9 @@ def run-suite [
             --commands $"
                 use ($runner_module) *
                 source ($path)
-                nutest-299792458-execute-suite ($strategy | to nuon) ($suite) ($plan_data)
+                let full_path = '($path)' | path expand
+                let span_offset = view files | where filename == $full_path | first | get start
+                nutest-299792458-execute-suite ($strategy | to nuon) ($suite) ($plan_data) --span-offset $span_offset
         " | complete)
     }
 
@@ -106,7 +108,11 @@ def process-event [
     event_processor: record<run-start: closure, run-complete: closure, test-start: closure, test-complete: closure>
 ] {
     let event = $in
-    let template = { suite: $event.suite, test: $event.test }
+    let template = {
+        suite: $event.suite
+        span_offset: $event.span_offset
+        test: $event.test
+    }
 
     match $event {
         { type: "start" } => {

--- a/nutest/returns/returns_table.nu
+++ b/nutest/returns/returns_table.nu
@@ -1,8 +1,40 @@
 use ../store.nu
 use ../formatter.nu
 
+use std-rfc/iter [recurse]
+
+def error-span-offset [offset: int]: [
+	record<msg, labels, code, url, help, inner> -> record<msg, labels, code, url, help, inner>
+] {
+	let IN
+	$IN
+	| recurse --depth-first inner
+	| update item.labels.span {
+		{
+			start: ($in.start - $offset)
+			end: ($in.end - $offset)
+		}
+	}
+	| reduce -f $IN {|e| upsert $e.path $e.item}
+}
+
 export def create []: nothing -> record {
-    let formatter = formatter unformatted
+	let formatter = {|row|
+		each {|msg| $msg.items }
+        | flatten
+		| each {|e|
+            match $e {
+                {$msg, $rendered, $json} => {
+                    {
+                        msg: $msg
+                        rendered: $rendered
+                        data: ($json | from json | error-span-offset $row.span_offset)
+                    }
+                }
+                $_ => $_
+            }
+		}
+	}
 
     {
         name: "returns table"
@@ -19,7 +51,7 @@ def query-results [
             suite: $row.suite
             test: $row.test
             result: $row.result
-            output: ($row.output | do $formatter)
+            output: ($row.output | do $formatter $row)
         }
     }
 }

--- a/nutest/runner.nu
+++ b/nutest/runner.nu
@@ -23,9 +23,14 @@ export def nutest-299792458-execute-suite [
     default_strategy: record<threads: int>
     suite: string
     suite_data: table
+    --span-offset: int
 ] {
     # We reset the test name to avoid collisions around tests within tests
-    with-env { NU_TEST_SUITE_NAME: $suite, NU_TEST_NAME: null } {
+    with-env {
+        NU_TEST_SUITE_NAME: $suite
+        NU_TEST_SPAN_OFFSET: $span_offset
+        NU_TEST_NAME: null
+    } {
         nutest-299792458-execute-suite-internal $default_strategy $suite_data
     }
 
@@ -193,6 +198,7 @@ def nutest-299792458-emit [type: string, payload: any = null] {
     let event = {
         timestamp: (date now | format date "%+")
         suite: $env.NU_TEST_SUITE_NAME
+        span_offset: $env.NU_TEST_SPAN_OFFSET?
         test: $env.NU_TEST_NAME?
         type: $type
         payload: $payload

--- a/nutest/store.nu
+++ b/nutest/store.nu
@@ -11,6 +11,7 @@ export def create [] {
             suite TEXT NOT NULL,
             test TEXT NULL,
             result TEXT NOT NULL,
+            span_offset INT,
             PRIMARY KEY (suite, test)
         )
     "
@@ -19,7 +20,8 @@ export def create [] {
         CREATE TABLE nu_test_output (
             suite TEXT NOT NULL,
             test TEXT NULL,
-            data TEXT NOT NULL
+            data TEXT NOT NULL,
+            span_offset INT
         )
     "
 
@@ -38,14 +40,15 @@ export def delete [] {
 export def insert-result [ row: record<suite: string, test: string, result: string> ] {
     retry-on-lock "nu_test_results" {
         stor open | query db "
-            INSERT INTO nu_test_results (suite, test, result)
-            VALUES (:suite, :test, :result)
+            INSERT INTO nu_test_results (suite, test, result, span_offset)
+            VALUES (:suite, :test, :result, :span_offset)
             ON CONFLICT(suite, test)
             DO UPDATE SET result = excluded.result
         " --params {
             suite: $row.suite
             test: $row.test
             result: $row.result
+            span_offset: $row.span_offset
         }
     }
 
@@ -107,10 +110,10 @@ export def success []: nothing -> bool {
     not $has_failures
 }
 
-export def query []: nothing -> table<suite: string, test: string, result: string, output: table<stream: string, items: list<any>>> {
+export def query []: nothing -> table<suite: string, test: string, result: string, span_offset: int, output: table<stream: string, items: list<any>>> {
     let db = stor open
     $db | query db "
-        SELECT suite, test, result
+        SELECT suite, test, result, span_offset
         FROM nu_test_results
         ORDER BY suite, test
     " | insert output { |row|
@@ -138,7 +141,7 @@ def query-result [
 
     $db
         | query db "
-            SELECT suite, test, result
+            SELECT suite, test, result, span_offset
             FROM nu_test_results
             WHERE suite = :suite AND test = :test
         " --params { suite: $suite test: $test }

--- a/tests/test_orchestrator.nu
+++ b/tests/test_orchestrator.nu
@@ -113,8 +113,8 @@ def run-suite-with-broken-test [] {
 
     let test_file = $temp | path join "broken-test.nu"
     "def broken-test" | save $test_file # Parse error
-    let tests = [{ name: "broken-test", type: "test" }]
-    let suites = [{ name: "broken", path: $test_file, tests: $tests }]
+    let tests = [{ name: "broken-test", type: "test", span_offset: 0 }]
+    let suites = [{ name: "broken", path: $test_file, tests: $tests, span_offset: 0 }]
     let results = $suites | test-run $context
 
     assert equal ($results | reject output) [
@@ -303,7 +303,7 @@ def test-run [context: record]: list<record> -> list<record> {
     $suites | run-suites (noop-event-processor) { threads: 1 }
 
     let results = store query
-    $results | where suite in ($suites | get name)
+    $results | where suite in ($suites | get name) | reject span_offset
 }
 
 def noop-event-processor []: nothing -> record<run-start: closure, run-complete: closure, test-start: closure, test-complete: closure> {

--- a/tests/test_runner.nu
+++ b/tests/test_runner.nu
@@ -608,6 +608,7 @@ def test-run [suite: string, plan: list<record>]: nothing -> table<suite, test, 
                 }
             }
     )
+    | reject span_offset?
 }
 
 def decode-output []: string -> record<stream: string, items: list<any>> {


### PR DESCRIPTION
I started writing an editor/test-runner adapter (specifically for [nvim-neotest](https://github.com/nvim-neotest/neotest)) and wanted to have errors raised by tests to appear as editor diagnostics.

<img width="805" height="391" alt="image" src="https://github.com/user-attachments/assets/a1380276-ee43-4ea2-b313-a849c78f5400" />

This PR changes the output of `--returns table`, specifically it changes the error records in the `output` column: 
- from `record<msg: string, rendered: string, json: string>`
- to `record<msg: string, rendered: string, data: error_struct>` with `error_struct` as described `error make`'s help text:
  - msg: `string`
  - code: `string`
  - labels: `table<error_label>`
  - help: `string`
  - url: `string`
  - inner: `table<error_struct>`

Spans of error labels are adjusted to be relative to the test file.

### Caveats

- This implementation only works for errors that point to the test file that raised them, so errors pointing at the actual code that's being tested are not supported.
  It shouldn't be too hard to extend this to support errors pointing outside the test code.
- I don't think I understand `nutest`'s architecture well enough to do this in an optimal way.

Posting this PR to get the conversation started on this and get opinions before doing further work.